### PR TITLE
Add the ability to specify a custom pool template file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ phpfpm::pool { 'main':
         'max_execution_time' => '300',
     },
 }
+
+# Pool using a custom template file that you provide, rather than the stock template
+phpfpm::pool { 'www':
+    listen             => '127.0.0.1:9001',
+    pool_template_file => 'site/phpfpm/mypool.conf.erb',
+}
+
 ```
 
 Notify the php-fpm daemon of your custom php configuration changes:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,6 +31,7 @@ class phpfpm::params {
             $restart_command             = "service ${service_name} reload"
 
             # Pool configuration defaults
+            $pool_template_file           = 'phpfpm/pool.conf.erb'
             $pool_user                    = 'www-data'
             $pool_group                   = 'www-data'
             $pool_listen                  = '127.0.0.1:9000'
@@ -91,6 +92,7 @@ class phpfpm::params {
             $restart_command             = "systemctl reload ${service_name}"
 
             # Pool configuration defaults
+            $pool_template_file           = 'phpfpm/pool.conf.erb'
             $pool_user                    = 'http'
             $pool_group                   = 'http'
             $pool_listen                  = '127.0.0.1:9000'
@@ -151,6 +153,7 @@ class phpfpm::params {
             $restart_command             = "service ${service_name} reload"
 
             # Pool configuration defaults
+            $pool_template_file           = 'phpfpm/pool.conf.erb'
             $pool_user                    = 'apache'
             $pool_group                   = 'apache'
             $pool_listen                  = '127.0.0.1:9000'

--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -54,6 +54,7 @@ define phpfpm::pool (
     $php_admin_flag            = $phpfpm::params::pool_php_admin_flag,
     $service_name              = $phpfpm::params::service_name,
     $pool_dir                  = $phpfpm::params::pool_dir,
+    $pool_template_file        = $phpfpm::params::pool_template_file,
 )
 {
     $pool_file_path = "${pool_dir}/${name}.conf"
@@ -77,7 +78,7 @@ pm_max_spare_servers(${pm_max_spare_servers})" )
             owner    => 'root',
             group    => 'root',
             mode     => '0644',
-            content  => template('phpfpm/pool.conf.erb'),
+            content  => template($pool_template_file),
             require  => Class['Phpfpm::Package'],
             notify   => Service[$service_name],
         }


### PR DESCRIPTION
@Slashbunny phpfpm looks fantastic and I thank you for sharing it.  You've saved me a huge amount of work.

I think it might be useful to be able to override the default template used for the worker pool conf file, though.  With that in mind, I've added the $pool_template_file parameter to params.pp, with a default value to match the current 'phpfpm/pool.conf.erb'.  The phpfpm::pool now uses that parameter, so it could be overridden, as in the example I added to the README.md.

Is this a contribution you would interested in accepting?  If so, what should I change?  Is $pool_template_file the parameter name we should use, or should it be just $pool_template?

Thanks,

Tim
