### PR TITLE
YAML support for PHP-FPM pools.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@
 #
 class phpfpm (
   $ensure                      = 'present',
+  $pools                       = $phpfpm::params::pools,
   $poold_purge                 = $phpfpm::params::poold_purge,
   $package_name                = $phpfpm::params::package_name,
   $service_name                = $phpfpm::params::service_name,
@@ -42,6 +43,8 @@ class phpfpm (
 
   # Install package
   include 'phpfpm::package'
+
+  create_resources('::phpfpm::pool', $pools)
 
   # Manage service and configuration only if the package is present
   if $ensure != 'absent' {


### PR DESCRIPTION
In a phpfpm.yaml file I wanted to have something like this:

    phpfpm::poold_purge: true
    phpfpm::log_level: 'warning'
    phpfpm::error_log: '/var/log/php-fpm/error.log'
    phpfpm::pools:
      'phabricator':
        listen: '127.0.0.1:9000'
        user: apache
        group: apache
        pm: dynamic
        pm_max_children: 10
        pm_start_servers: 4
        pm_min_spare_servers: 2
        pm_max_spare_servers: 6
        pm_max_requests: 500

but because the pools were not handled as a resource. My humble PR is about to fix this.