### PR TITLE
add support for Debian jessie and stretch

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,20 +12,29 @@ class phpfpm::params {
 
       # Service configuration defaults
       # Ubuntu Xenial and above ship with php7 not php5
-      if versioncmp($::lsbdistrelease, '16.04') >= 0 {
+      if (( $::operatingsystem == 'Ubuntu' ) and ( versioncmp($::lsbdistrelease, '16.04') >= 0 )) {
         $package_name                   = 'php7.0-fpm'
         $service_name                   = 'php7.0-fpm'
         $config_dir                     = '/etc/php/7.0/fpm'
         $pid_file                       = '/var/run/php/php7.0-fpm.pid'
         $error_log                      = '/var/log/php7.0-fpm.log'
+      # Debian stretch and above ship with php7 not php5
+      } elsif (( $::operatingsystem == 'Debian' ) and ( versioncmp($::lsbdistrelease, '9.0') >= 0 )) {
+        $package_name                   = 'php7.0-fpm'
+        $service_name                   = 'php7.0-fpm'
+        $config_dir                     = '/etc/php/7.0/fpm'
+        $pid_file                       = '/run/php/php7.0-fpm.pid'
+        $error_log                      = '/var/log/php7.0-fpm.log'
       } else {
         $package_name                   = 'php5-fpm'
         $service_name                   = 'php5-fpm'
         $config_dir                     = '/etc/php5/fpm'
-        $pid_file                       = '/var/run/php5-fpm.pid'
+        case $::operatingsystem {
+          'Debian':         { $pid_file = '/run/php5-fpm.pid' }
+          default:          { $pid_file = '/var/run/php5-fpm.pid' }
+        }
         $error_log                      = '/var/log/php5-fpm.log'
       }
-
       $config_name                    = 'php-fpm.conf'
       $config_user                    = 'root'
       $config_group                   = 'root'

--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,7 @@
         },
         {
             "operatingsystem": "Debian",
-            "operatingsystemrelease": [ "7.0" ]
+            "operatingsystemrelease": [ "7.0", "8.0", "9.0" ]
         },
         {
             "operatingsystem": "ArchLinux",


### PR DESCRIPTION
Debian stretch uses php7 (like Ubuntu).
For older Debian releases, the pidfile was wrong.