### PR TITLE
Add openbsd support, including updates to metadata & version bump

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@
 # See README.md
 #
 class phpfpm (
-  $ensure                      = 'present',
+  $ensure                      = $phpfpm::params::ensure,
   $pools                       = undef,
   $poold_purge                 = $phpfpm::params::poold_purge,
   $package_name                = $phpfpm::params::package_name,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -5,8 +5,9 @@
 #
 class phpfpm::package {
 
-  package { $::phpfpm::package_name:
-    ensure => $::phpfpm::ensure,
+  package { 'php-fpm':
+    ensure =>  $::phpfpm::ensure,
+    name   =>  $::phpfpm::package_name,
   }
 }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class phpfpm::params {
     'debian': {
       # Module configuration defaults
       $poold_purge = false
+      $ensure      = 'present'
 
       # Service configuration defaults
       # Ubuntu Artful and above ship php 7.1
@@ -99,6 +100,7 @@ class phpfpm::params {
     'archlinux': {
       # Module configuration defaults
       $poold_purge = false
+      $ensure      = 'present'
 
       # Service configuration defaults
       $package_name                   = 'php-fpm'
@@ -163,6 +165,7 @@ class phpfpm::params {
     'redhat', 'linux': {
       # Module configuration defaults
       $poold_purge = false
+      $ensure      = 'present'
 
       # Service configuration defaults
       $package_name                   = 'php-fpm'
@@ -224,9 +227,78 @@ class phpfpm::params {
       $pool_php_admin_value           = {}
       $pool_php_admin_flag            = {}
     }
+    'openbsd': {
+      # Module configuration defaults
+      $poold_purge = false
+      $ensure      = $::kernelversion ? {
+        '6.2'      => '7.0.23',
+        default    => '%7',
+      }
+
+      # Service configuration defaults
+      $package_name                   = 'php'
+      $service_name                   = 'php70_fpm'
+      $config_dir                     = '/etc'
+      $config_name                    = 'php-fpm.conf'
+      $config_user                    = 'root'
+      $config_group                   = 'wheel'
+      $config_template_file           = 'phpfpm/php-fpm.conf.erb'
+      $pool_dir                       = "${config_dir}/php-fpm.d"
+      $pid_file                       = 'run/php-fpm.pid'
+      $error_log                      = 'log/php-fpm.log'
+      $syslog_facility                = 'daemon'
+      $syslog_ident                   = 'php-fpm'
+      $log_level                      = 'notice'
+      $emergency_restart_threshold    = 0
+      $emergency_restart_interval     = 0
+      $process_control_timeout        = 0
+      $process_max                    = 0
+      $daemonize                      = 'yes'
+      $rlimit_files                   = undef
+      $rlimit_core                    = undef
+      $restart_command                = "rcctl restart ${service_name}"
+
+      # Pool configuration defaults
+      $pool_template_file             = 'phpfpm/pool.conf.erb'
+      $pool_user                      = 'www'
+      $pool_group                     = 'www'
+      $pool_listen                    = '127.0.0.1:9000'
+      $pool_listen_backlog            = undef
+      $pool_listen_owner              = undef
+      $pool_listen_group              = undef
+      $pool_listen_mode               = undef
+      $pool_listen_allowed_clients    = undef
+      $pool_pm                        = 'dynamic'
+      $pool_pm_max_children           = 10
+      $pool_pm_start_servers          = 4
+      $pool_pm_min_spare_servers      = 2
+      $pool_pm_max_spare_servers      = 6
+      $pool_pm_process_idle_timeout   = undef
+      $pool_pm_max_requests           = undef
+      $pool_pm_status_path            = undef
+      $pool_ping_path                 = undef
+      $pool_ping_response             = undef
+      $pool_access_log                = undef
+      $pool_access_format             = undef
+      $pool_slowlog                   = undef
+      $pool_req_slowlog_timeout       = undef
+      $pool_req_terminate_timeout     = undef
+      $pool_rlimit_files              = undef
+      $pool_rlimit_core               = undef
+      $pool_chroot                    = undef
+      $pool_chdir                     = '/'
+      $pool_catch_workers_output      = undef
+      $pool_security_limit_extensions = undef
+      $pool_env                       = {}
+      $pool_php_value                 = {}
+      $pool_php_flag                  = {}
+      $pool_php_admin_value           = {}
+      $pool_php_admin_flag            = {}
+    }
     'freebsd': {
       # Module configuration defaults
       $poold_purge = false
+      $ensure      = 'present'
 
       # Service configuration defaults
       $package_name                   = 'php70'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "Slashbunny-phpfpm",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "author": "Slashbunny",
     "summary": "Manages php-fpm daemon and pool configuration",
     "license": "GPL-3.0",
@@ -38,6 +38,10 @@
         {
             "operatingsystem": "FreeBSD",
             "operatingsystemrelease": [ "10+" ]
+        },
+        {
+            "operatingsystem": "OpenBSD",
+            "operatingsystemrelease": [ "6.1", "6.2"  ]
         }
     ]
 }


### PR DESCRIPTION
This needed changes to support the openbsd package branch/ambiguity matching:
 - Changes package install to name, distinct from namevar
 - default to package => specific version for openbsd platform
 - include a selector for additional openbsd specific package versioning