### PR TITLE
add support for ubuntu 18.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,8 +13,15 @@ class phpfpm::params {
       $manage_package = true
 
       # Service configuration defaults
+      # Ubuntu Bionic and above ship php 7.2
+      if (( $::operatingsystem == 'Ubuntu' ) and ( versioncmp($::lsbdistrelease, '18.04') >= 0 )) {
+        $package_name                   = 'php7.2-fpm'
+        $service_name                   = 'php7.2-fpm'
+        $config_dir                     = '/etc/php/7.2/fpm'
+        $pid_file                       = '/var/run/php/php7.2-fpm.pid'
+        $error_log                      = '/var/log/php7.2-fpm.log'
       # Ubuntu Artful and above ship php 7.1
-      if (( $::operatingsystem == 'Ubuntu' ) and ( versioncmp($::lsbdistrelease, '17.10') >= 0 )) {
+      } elsif (( $::operatingsystem == 'Ubuntu' ) and ( versioncmp($::lsbdistrelease, '17.10') >= 0 )) {
         $package_name                   = 'php7.1-fpm'
         $service_name                   = 'php7.1-fpm'
         $config_dir                     = '/etc/php/7.1/fpm'


### PR DESCRIPTION
Tested on my server.

I still had to hack my way around to have the pkg installed but it is unrelated to the puppet code: the pkg won't finish its install if post script can't start the service but the service won't start if no pool are defined.

Not sure if I did not have any pool because of the puppet class purge parameter or if the package itself is broken.