### PR TITLE
versioncomp fails if there is no security release yet

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,35 +15,35 @@ class phpfpm::params {
 
       # Service configuration defaults
       # Ubuntu Bionic and above ship php 7.2
-      if (( $::operatingsystem == 'Ubuntu' ) and ( versioncmp($::lsbdistrelease, '18.04') >= 0 )) {
+      if $facts['os']['family'] == 'Ubuntu' and Integer($facts['os']['release']['major']) == 18 {
         $package_name                   = 'php7.2-fpm'
         $service_name                   = 'php7.2-fpm'
         $config_dir                     = '/etc/php/7.2/fpm'
         $pid_file                       = '/var/run/php/php7.2-fpm.pid'
         $error_log                      = '/var/log/php7.2-fpm.log'
       # Ubuntu Artful and above ship php 7.1
-      } elsif (( $::operatingsystem == 'Ubuntu' ) and ( versioncmp($::lsbdistrelease, '17.10') >= 0 )) {
+      } elsif $facts['os']['family'] == 'Ubuntu' and Integer($facts['os']['release']['major']) == 17 {
         $package_name                   = 'php7.1-fpm'
         $service_name                   = 'php7.1-fpm'
         $config_dir                     = '/etc/php/7.1/fpm'
         $pid_file                       = '/var/run/php/php7.1-fpm.pid'
         $error_log                      = '/var/log/php7.1-fpm.log'
       # Ubuntu Xenial and above ship with php7 not php5
-      } elsif (( $::operatingsystem == 'Ubuntu' ) and ( versioncmp($::lsbdistrelease, '16.04') >= 0 )) {
+      } elsif $facts['os']['family'] == 'Ubuntu' and Integer($facts['os']['release']['major']) == 16 {
         $package_name                   = 'php7.0-fpm'
         $service_name                   = 'php7.0-fpm'
         $config_dir                     = '/etc/php/7.0/fpm'
         $pid_file                       = '/var/run/php/php7.0-fpm.pid'
         $error_log                      = '/var/log/php7.0-fpm.log'
       # Debian buster is ship with php7.3
-      } elsif (( $::operatingsystem == 'Debian' ) and ( versioncmp($::lsbdistrelease, '10.0') >= 0 )) {
+      } elsif $facts['os']['family'] == 'Debian' and Integer($facts['os']['release']['major']) == 10 {
         $package_name                   = 'php7.3-fpm'
         $service_name                   = 'php7.3-fpm'
         $config_dir                     = '/etc/php/7.3/fpm'
         $pid_file                       = '/run/php/php7.3-fpm.pid'
         $error_log                      = '/var/log/php7.3-fpm.log'
       # Debian stretch and above ship with php7 not php5
-      } elsif (( $::operatingsystem == 'Debian' ) and ( versioncmp($::lsbdistrelease, '9.0') >= 0 )) {
+      } elsif $facts['os']['family'] == 'Debian' and Integer($facts['os']['release']['major']) == 9 {
         $package_name                   = 'php7.0-fpm'
         $service_name                   = 'php7.0-fpm'
         $config_dir                     = '/etc/php/7.0/fpm'


### PR DESCRIPTION
Hello Slashbunny,
I've just discovered that your changes for Debian "Buster" in the params.pp fail because there is no security release yet.
lsb_release returns "10" which can not be compared against "10.0".

Therefore I've changed the version matching to the recommended way using $facts['os']... comparing only to the major release.

It is on my side tested and working on Debian (Jessie, Stretch, Buster).

best regards,
Stefan