### PR TITLE
Bugfix: Configure files after package installation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,10 +56,11 @@ class phpfpm (
     # Manage daemon
     include 'phpfpm::service'
 
-    Class['phpfpm::package'] -> Class['phpfpm::service']
+    Class['phpfpm::package'] ~> Class['phpfpm::service']
 
     file { $pool_dir:
-      ensure => 'directory',
+      ensure  => 'directory',
+      require => Class['phpfpm::package'],
     }
 
     # Purge pool.d if necessary
@@ -75,6 +76,7 @@ class phpfpm (
     file { "${config_dir}/${config_name}":
       ensure  => 'present',
       content => template($config_template_file),
+      require => Class['phdfm::package'],
       notify  => Class['phpfpm::service'],
     }
   }

--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -73,7 +73,7 @@ define phpfpm::pool (
     group   => $config_group,
     mode    => '0644',
     content => template($pool_template_file),
-    require => Class['Phpfpm::Package'],
+    require => Class['phpfpm::package'],
     notify  => Service[$service_name],
   }
 }


### PR DESCRIPTION
Hi

This commit fixes  an ordering violation found in manifests.
Package installation must precede configuration of files.

This is the error I get, when Puppet configures files **before** package installation.

```
Notice: Compiled catalog for 9e268c087315 in environment production in 0.18 seconds
Error: Cannot create /etc/php/7.0/fpm/pool.d; parent directory /etc/php/7.0/fpm does not exist
Error: /Stage[main]/Phpfpm/File[/etc/php/7.0/fpm/pool.d]/ensure: change from absent to directory failed: Cannot create /etc/php/7.0/fpm/pool.d; parent directory /etc/php/7.0/fpm does not exist
Error: Could not set 'present' on ensure: No such file or directory @ dir_s_mkdir - /etc/php/7.0/fpm/php-fpm.conf20191130-9352-1rjo4co.lock at /etc/puppet/code/modules/phpfpm/manifests/init.pp:75
Error: Could not set 'present' on ensure: No such file or directory @ dir_s_mkdir - /etc/php/7.0/fpm/php-fpm.conf20191130-9352-1rjo4co.lock at /etc/puppet/code/modules/phpfpm/manifests/init.pp:75
Wrapped exception:
No such file or directory @ dir_s_mkdir - /etc/php/7.0/fpm/php-fpm.conf20191130-9352-1rjo4co.lock
Error: /Stage[main]/Phpfpm/File[/etc/php/7.0/fpm/php-fpm.conf]/ensure: change from absent to present failed: Could not set 'present' on ensure: No such file or directory @ dir_s_mkdir - /etc/php/7.0/fpm/php-fpm.conf20191130-9352-1rjo4co.lock at /etc/puppet/code/modules/phpfpm/manifests/init.pp:75
Notice: /Stage[main]/Phpfpm::Package/Package[php-fpm]/ensure: created
Notice: /Stage[main]/Phpfpm::Service/Service[php7.0-fpm]: Dependency File[/etc/php/7.0/fpm/php-fpm.conf] has failures: true
Warning: /Stage[main]/Phpfpm::Service/Service[php7.0-fpm]: Skipping because of failed dependencies
Notice: Applied catalog in 10.06 seconds
```