### PR TITLE
Fix the name of the phpfpm::package class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,7 +76,7 @@ class phpfpm (
     file { "${config_dir}/${config_name}":
       ensure  => 'present',
       content => template($config_template_file),
-      require => Class['phdfm::package'],
+      require => Class['phpfpm::package'],
       notify  => Class['phpfpm::service'],
     }
   }


### PR DESCRIPTION
This commit fixes a typo introduced in a previous pull request (see #33)

Sorry again.