### PR TITLE
add hiera.yaml and defaults for Debian 11 bullseye

### DIFF
--- a/data/Debian/Debian_11.yaml
+++ b/data/Debian/Debian_11.yaml
@@ -1,0 +1,11 @@
+---
+# defaults for Debian 11 (bullseye)
+
+phpfpm::package_name: 'php7.4-fpm'
+phpfpm::service_name: 'php7.4-fpm'
+phpfpm::config_dir: '/etc/php/7.4/fpm'
+phpfpm::pid_file: '/run/php/php7.4-fpm.pid'
+phpfpm::error_log: '/var/log/php7.4-fpm.log'
+
+phpfpm::pool_dir: '/etc/php/7.4/fpm/pool.d'
+phpfpm::restart_command: 'service php7.4-fpm reload'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,16 @@
+---
+version: 5
+
+defaults:
+  datadir: 'data'
+  data_hash: 'yaml_data'
+
+hierarchy:
+  - name: 'module phpfpm, per os version'
+    path: '%{facts.os.family}/%{facts.os.name}_%{facts.os.release.major}.yaml'
+
+  - name: 'module phpfpm, per os'
+    path: '%{facts.os.family}/%{facts.os.name}.yaml'
+
+  - name: 'module phpfpm, os-family'
+    path: '%{facts.os.family}/common.yaml'


### PR DESCRIPTION
I think we should switch to hiera configuration instead of params.pp.
So I start with support for Debian bullseye !