### PR TITLE
feat: Make fpm service start and stoppable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,8 @@ class phpfpm (
   $rlimit_files                = $phpfpm::params::rlimit_files,
   $rlimit_core                 = $phpfpm::params::rlimit_core,
   $restart_command             = $phpfpm::params::restart_command,
+  $ensure_service              = $phpfpm::params::ensure_service,
+  $enable_service              = $phpfpm::params::enable_service,
 ) inherits phpfpm::params {
   # Install package
   include 'phpfpm::package'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -95,6 +95,8 @@ class phpfpm::params {
       $rlimit_files                   = undef
       $rlimit_core                    = undef
       $restart_command                = "service ${service_name} reload"
+      $ensure_service                 = 'running'
+      $enable_service                 = true
 
       # Pool configuration defaults
       $pool_template_file             = 'phpfpm/pool.conf.erb'
@@ -160,6 +162,8 @@ class phpfpm::params {
       $rlimit_files                   = undef
       $rlimit_core                    = undef
       $restart_command                = "systemctl reload ${service_name}"
+      $ensure_service                 = 'running'
+      $enable_service                 = true
 
       # Pool configuration defaults
       $pool_template_file             = 'phpfpm/pool.conf.erb'
@@ -225,6 +229,8 @@ class phpfpm::params {
       $rlimit_files                   = undef
       $rlimit_core                    = undef
       $restart_command                = "service ${service_name} reload"
+      $ensure_service                 = 'running'
+      $enable_service                 = true
 
       # Pool configuration defaults
       $pool_template_file             = 'phpfpm/pool.conf.erb'
@@ -293,6 +299,8 @@ class phpfpm::params {
       $rlimit_files                   = undef
       $rlimit_core                    = undef
       $restart_command                = "rcctl restart ${service_name}"
+      $ensure_service                 = 'running'
+      $enable_service                 = true
 
       # Pool configuration defaults
       $pool_template_file             = 'phpfpm/pool.conf.erb'
@@ -358,6 +366,8 @@ class phpfpm::params {
       $rlimit_files                   = undef
       $rlimit_core                    = undef
       $restart_command                = "service ${service_name} reload"
+      $ensure_service                 = 'running'
+      $enable_service                 = true
 
       # Pool configuration defaults
       $pool_template_file             = 'phpfpm/pool.conf.erb'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,8 +6,8 @@
 #
 class phpfpm::service {
   service { $phpfpm::service_name:
-    ensure     => 'running',
-    enable     => true,
+    ensure     => $phpfpm::ensure_service,
+    enable     => $phpfpm::enable_service,
     hasstatus  => true,
     hasrestart => true,
     restart    => $phpfpm::restart_command,


### PR DESCRIPTION
This implements options to control whether the fpm service should be running or stopped. Additionally you can now control if the service should be started on system boot or not.